### PR TITLE
Use a relative path when testing non-empty output dir

### DIFF
--- a/features/user_errors.feature
+++ b/features/user_errors.feature
@@ -57,27 +57,24 @@ Feature: Providing useful errors to a user when they run the tool incorrectly
     And the exit code should be 1
 
     Examples:
-      | command | type                 | args                                       |
+      | command | type                 | args                                              |
       | run     | short_read_assembler | --input=reads.fq.gz --output=$(realpath .)/output |
-      | login   | short_read_assembler |                                            |
-      | verify  | short_read_assembler |                                            |
+      | login   | short_read_assembler |                                                   |
+      | verify  | short_read_assembler |                                                   |
 
-  Scenario Outline: Trying to mount a non empty output directory.
+  Scenario: Trying to mount a non-empty output directory
     Given I create the directory "output"
     And I copy the example data files:
-      | source         | dest                 |
+      | source         | dest                  |
       | assembly.fasta | output/assembly.fasta |
     When I run the command:
       """
-      biobox run short_read_assembler bioboxes/velvet --input=reads.fq.gz --output <output>
+      biobox run short_read_assembler bioboxes/velvet --input=reads.fq.gz --output=output
       """
     Then the stdout should be empty
     And the exit code should be 1
     And the stderr should equal:
       """
-      Specified output directory "<output>" is not empty.
-      """
+      Specified output directory "output" is not empty.
 
-    Examples:
-     | output             |
-     | $(realpath .)/output |
+      """


### PR DESCRIPTION
This should fix the failing feature tests, though I would like to discuss the proposed changes in your branch before we merge this into the next release branch.
